### PR TITLE
The CJS build of Vite's Node API is deprecated, has been changed to m…

### DIFF
--- a/templates/base-JavaScript/package.json
+++ b/templates/base-JavaScript/package.json
@@ -1,6 +1,7 @@
 {
     "name": "{{projectName}}",
     "version": "{{version}}",
+    "type": "module",
     "description": "{{description}}",
     "author": "{{author}}",
     "main": "src/main.jsx",
@@ -20,7 +21,7 @@
     "devDependencies": {
         "esbuild": "^0.20.2",
         "nodemon": "^3.1.9",
-        "vite": "^6.0.5",
+        "vite": "^6.0.11",
         "vite-plugin-singlefile": "^2.1.0",
         "vite-plugin-static-copy": "^2.2.0"
     }


### PR DESCRIPTION
…odule.